### PR TITLE
[Feat] 위치권한 및 가게 온오프수정

### DIFF
--- a/app/src/main/java/app/threedollars/manager/storeManagement/ui/MyScreen.kt
+++ b/app/src/main/java/app/threedollars/manager/storeManagement/ui/MyScreen.kt
@@ -62,7 +62,7 @@ fun MyScreen(viewModel: MyViewModel = hiltViewModel()) {
         bossStore.value?.let {
             val introduction = it.introduction.ifEmpty { "손님들에게 감동을 드릴 한마디를 적어주세요!ex) 오전에 오시면 서비스가 있습니다!" }
             displayProfileInfo(Profile(it.imageUrl, it.name, it.categories.map { it.name.toStringDefault() }, it.snsUrl)) {
-                context.startActivity(Intent(context, ProfileEditActivity::class.java))
+                launcher.launch(Intent(context, ProfileEditActivity::class.java))
             }
             Spacer(modifier = Modifier.height(44.dp))
             Column(
@@ -97,11 +97,13 @@ fun MyScreen(viewModel: MyViewModel = hiltViewModel()) {
                 TitleContents(bottomPadding = 16.dp, Title("영업 일정", "일정 관리") {
                     launcher.launch(Intent(context, BusinessScheduleEditActivity::class.java))
                 })
-                it.appearanceDays.map { dto -> dto.toBusinessSchedule() }.forEach { businessSchedules ->
-                    val index = emptyBusinessSchedules.indexOfFirst { it.dayOfTheWeek == businessSchedules.dayOfTheWeek }
-                    emptyBusinessSchedules[index] = businessSchedules
+                val businessSchedules = mutableListOf<BusinessSchedule>()
+                businessSchedules.addAll(emptyBusinessSchedules)
+                it.appearanceDays.map { dto -> dto.toBusinessSchedule() }.forEach { businessSchedule ->
+                    val index = businessSchedules.indexOfFirst { it.dayOfTheWeek == businessSchedule.dayOfTheWeek }
+                    businessSchedules[index] = businessSchedule
                 }
-                BusinessScheduleContents(emptyBusinessSchedules)
+                BusinessScheduleContents(businessSchedules)
                 Spacer(modifier = Modifier.height(64.dp))
             }
         }
@@ -288,7 +290,7 @@ data class BusinessSchedule(
     val isWeekend: Boolean
 )
 
-val emptyBusinessSchedules = mutableListOf(
+val emptyBusinessSchedules = listOf(
     BusinessSchedule("월요일", "MONDAY", "-", "휴무", false, isWeekend = false),
     BusinessSchedule("화요일", "TUESDAY", "-", "휴무", false, isWeekend = false),
     BusinessSchedule("수요일", "WEDNESDAY", "-", "휴무", false, isWeekend = false),

--- a/app/src/main/java/app/threedollars/manager/storeManagement/ui/businessschedule/BusinessScheduleEditActivity.kt
+++ b/app/src/main/java/app/threedollars/manager/storeManagement/ui/businessschedule/BusinessScheduleEditActivity.kt
@@ -1,5 +1,6 @@
 package app.threedollars.manager.storeManagement.ui.businessschedule
 
+import android.app.Activity.RESULT_OK
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
@@ -54,7 +55,10 @@ fun BusinessScheduleEditScreen(viewModel: BusinessScheduleEditViewModel = hiltVi
     val editComplete by viewModel.editComplete.collectAsStateWithLifecycle(initialValue = false)
     val isEnable by viewModel.enableComplete.collectAsStateWithLifecycle(initialValue = false)
     LaunchedEffect(editComplete) {
-        if (editComplete) context.findActivity().finish()
+        if (editComplete) {
+            context.findActivity().setResult(RESULT_OK)
+            context.findActivity().finish()
+        }
     }
     bossStore?.appearanceDays?.forEach {
         it.dayOfTheWeek
@@ -212,9 +216,9 @@ fun BusinessScheduleDayDetail(
     endTimeChanged: (String) -> Unit = {},
     locationDescriptionChanged: (String) -> Unit = {}
 ) {
-    var startTime by remember { mutableStateOf("시작시간") }
-    var endTime by remember { mutableStateOf("종료시간") }
-    var locationDescription by remember { mutableStateOf("") }
+    var startTime by remember(scheduleDay) { mutableStateOf(scheduleDay.startTime.ifEmpty { "시작시간" }) }
+    var endTime by remember(scheduleDay) { mutableStateOf(scheduleDay.endTime.ifEmpty { "종료시간" }) }
+    var locationDescription by remember(scheduleDay) { mutableStateOf(scheduleDay.locationDescription) }
     val startTimeDialogState = rememberMaterialDialogState()
     MaterialDialog(
         dialogState = startTimeDialogState,

--- a/app/src/main/java/app/threedollars/manager/storeManagement/ui/profile/ProfileEditActivity.kt
+++ b/app/src/main/java/app/threedollars/manager/storeManagement/ui/profile/ProfileEditActivity.kt
@@ -1,5 +1,7 @@
 package app.threedollars.manager.storeManagement.ui.profile
 
+import android.app.Activity
+import android.app.Activity.RESULT_OK
 import android.net.Uri
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -67,7 +69,10 @@ fun ProfileEditScreen(viewModel: ProfileEditViewModel = hiltViewModel()) {
     val imageUrl by remember(bossStore) { mutableStateOf(bossStore?.imageUrl.toStringDefault()) }
     isEnable = (name.isNotEmpty() && name != bossStore?.name) || selectedList.isNotEmpty()
     LaunchedEffect(editComplete) {
-        if (editComplete) context.findActivity().finish()
+        if (editComplete) {
+            context.findActivity().setResult(RESULT_OK)
+            context.findActivity().finish()
+        }
     }
     Column(
         modifier = Modifier

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -41,7 +41,7 @@ object Versions {
     const val MOSHI_CONVERTER = "2.4.0"
     const val OKHTTP = "4.9.1"
 
-    const val NAVER_MAP_COMPOSE = "1.3.1"
+    const val NAVER_MAP_COMPOSE = "1.3.3"
     const val LOTTIE_COMPOSE = "5.2.0"
 
     const val DIALOG_COMPOSE = "0.9.0"

--- a/domain/src/main/java/app/threedollars/domain/dto/BossStoreRetrieveDto.kt
+++ b/domain/src/main/java/app/threedollars/domain/dto/BossStoreRetrieveDto.kt
@@ -11,7 +11,7 @@ data class BossStoreRetrieveDto(
     val imageUrl: String? = null,
     val introduction: String? = null,
     val location: LocationDto? = null,
-    val menus: List<MenusDto>,
+    val menus: List<MenusDto> = listOf(),
     val name: String? = null,
     val openStatus: OpenStatusDto? = null,
     val snsUrl: String? = null,


### PR DESCRIPTION
위치권한과 가게온오프 까지는 일단 해두었습니다.
가게정보 갱신쪽도 손봐둬서 전체적인 흐름을 따라가는덴 문제가 없는 것 같습니다.
지도 마커쪽은 네이버컴포즈쪽을 좀 더 봐서 저희앱에 맞게끔 구현가능할지 좀 더 봐야 할 것 같아요
단순하게 내 위치만 팔로우하는기능은 아니다보니까 ...
일단 당장 테스트에문제될부분부터 먼저 수정해두었고 마커쪽은 좀 더 개발해보겠습니다

매번 가게정보를 호출하는게 걸리는데 이부분을 공통변수로 빼서 수정할때마다 앱내에서 수정하게끔 하면 좋을 것 같은데 이것까지해서 내보내는게 좋을까요?? 