### PR TITLE
[Feat] UA 변경 작업

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
         minSdk = 23
         targetSdk = 33
         versionCode = 1
-        versionName = "0.0.0-alpha01"
+        versionName = "0.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/app/threedollars/manager/di/UseCaseModule.kt
+++ b/app/src/main/java/app/threedollars/manager/di/UseCaseModule.kt
@@ -55,4 +55,8 @@ abstract class UseCaseModule {
     @ViewModelScoped
     @Binds
     abstract fun bindPlatformStoreCategoryUseCase(impl: PlatformStoreCategoryUseCaseImpl): PlatformStoreCategoryUseCase
+
+    @ViewModelScoped
+    @Binds
+    abstract fun bindAppConfigUseCase(impl: AppConfigUseCaseImpl): AppConfigUseCase
 }

--- a/app/src/main/java/app/threedollars/manager/sign/viewmodel/SplashViewModel.kt
+++ b/app/src/main/java/app/threedollars/manager/sign/viewmodel/SplashViewModel.kt
@@ -4,9 +4,11 @@ import androidx.lifecycle.viewModelScope
 import app.threedollars.common.BaseViewModel
 import app.threedollars.common.EventFlow
 import app.threedollars.common.MutableEventFlow
+import app.threedollars.domain.usecase.AppConfigUseCase
 import app.threedollars.domain.usecase.AuthUseCase
 import app.threedollars.domain.usecase.BossAccountUseCase
 import app.threedollars.domain.usecase.BossDeviceUseCase
+import app.threedollars.manager.BuildConfig
 import app.threedollars.manager.sign.LoginNavItem
 import com.google.firebase.messaging.FirebaseMessaging
 import com.kakao.sdk.auth.AuthApiClient
@@ -24,14 +26,23 @@ import javax.inject.Inject
 class SplashViewModel @Inject constructor(
     private val authUseCase: AuthUseCase,
     private val bossAccountUseCase: BossAccountUseCase,
-    private val bossDeviceUseCase: BossDeviceUseCase
+    private val bossDeviceUseCase: BossDeviceUseCase,
+    private val appConfigUseCase: AppConfigUseCase
 ) : BaseViewModel() {
 
     private val _loginNavItem = MutableEventFlow<LoginNavItem>()
     val loginNavItem: EventFlow<LoginNavItem> get() = _loginNavItem
 
     init {
+        saveAppConfig()
         autoLogin()
+    }
+
+    private fun saveAppConfig() {
+        viewModelScope.launch {
+            appConfigUseCase.saveApplicationId(BuildConfig.APPLICATION_ID).collect()
+            appConfigUseCase.saveVersionName(BuildConfig.VERSION_NAME).collect()
+        }
     }
 
     private fun login(accessToken: String) {

--- a/app/src/main/java/app/threedollars/manager/usecase/AppConfigUseCaseImpl.kt
+++ b/app/src/main/java/app/threedollars/manager/usecase/AppConfigUseCaseImpl.kt
@@ -1,0 +1,12 @@
+package app.threedollars.manager.usecase
+
+import app.threedollars.domain.repository.AppConfigRepository
+import app.threedollars.domain.usecase.AppConfigUseCase
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class AppConfigUseCaseImpl @Inject constructor(private val appConfigRepository: AppConfigRepository) : AppConfigUseCase {
+    override suspend fun saveVersionName(version: String): Flow<Unit> = appConfigRepository.saveVersionName(version)
+
+    override suspend fun saveApplicationId(applicationId: String): Flow<Unit> = appConfigRepository.saveApplicationId(applicationId)
+}

--- a/data/src/main/java/app/threedollars/di/RepositoryModule.kt
+++ b/data/src/main/java/app/threedollars/di/RepositoryModule.kt
@@ -1,7 +1,9 @@
 package app.threedollars.di
 
+import app.threedollars.domain.repository.AppConfigRepository
 import app.threedollars.domain.repository.StoreRepository
 import app.threedollars.domain.repository.UserRepository
+import app.threedollars.repository.AppConfigRepositoryImpl
 import app.threedollars.repository.StoreRepositoryImpl
 import app.threedollars.repository.UserRepositoryImpl
 import dagger.Binds
@@ -21,4 +23,8 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun provideStoreRepository(impl: StoreRepositoryImpl): StoreRepository
+
+    @Binds
+    @Singleton
+    abstract fun provideAppConfigRepository(impl: AppConfigRepositoryImpl): AppConfigRepository
 }

--- a/data/src/main/java/app/threedollars/repository/AppConfigRepositoryImpl.kt
+++ b/data/src/main/java/app/threedollars/repository/AppConfigRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package app.threedollars.repository
+
+import app.threedollars.domain.repository.AppConfigRepository
+import app.threedollars.source.LocalDataSource
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class AppConfigRepositoryImpl @Inject constructor(
+    private val localDataSource: LocalDataSource
+) : AppConfigRepository {
+    override suspend fun saveVersionName(version: String): Flow<Unit> = localDataSource.saveVersionName(version)
+
+    override suspend fun saveApplicationId(applicationId: String): Flow<Unit> = localDataSource.saveApplicationId(applicationId)
+}

--- a/data/src/main/java/app/threedollars/source/LocalDataSource.kt
+++ b/data/src/main/java/app/threedollars/source/LocalDataSource.kt
@@ -6,7 +6,11 @@ interface LocalDataSource {
 
     suspend fun saveSocialAccessToken(token: String): Flow<Unit>
     suspend fun saveAccessToken(token: String): Flow<Unit>
+    suspend fun saveVersionName(version: String): Flow<Unit>
+    suspend fun saveApplicationId(applicationId: String): Flow<Unit>
 
     fun getSocialAccessToken(): Flow<String>
     fun getAccessToken(): Flow<String>
+    fun getVersionName(): Flow<String>
+    fun getApplicationId(): Flow<String>
 }

--- a/data/src/main/java/app/threedollars/source/LocalDataSourceImpl.kt
+++ b/data/src/main/java/app/threedollars/source/LocalDataSourceImpl.kt
@@ -10,15 +10,30 @@ class LocalDataSourceImpl @Inject constructor(private val dataStoreManager: Data
         emit(dataStoreManager.saveStringData(SOCIAL_ACCESS_TOKEN, token))
     }
 
-    override suspend fun saveAccessToken(token: String) = flow{
-        emit(dataStoreManager.saveStringData(ACCESS_TOKEN,token))
+    override suspend fun saveAccessToken(token: String) = flow {
+        emit(dataStoreManager.saveStringData(ACCESS_TOKEN, token))
+    }
+
+    override suspend fun saveVersionName(version: String) = flow {
+        emit(dataStoreManager.saveStringData(VERSION_NAME, version))
+    }
+
+    override suspend fun saveApplicationId(applicationId: String) = flow {
+        emit(dataStoreManager.saveStringData(APPLICATION_ID, applicationId))
     }
 
     override fun getSocialAccessToken(): Flow<String> = dataStoreManager.getStringData(SOCIAL_ACCESS_TOKEN)
     override fun getAccessToken(): Flow<String> = dataStoreManager.getStringData(ACCESS_TOKEN)
 
+
+    override fun getVersionName(): Flow<String> = dataStoreManager.getStringData(VERSION_NAME)
+
+    override fun getApplicationId(): Flow<String> = dataStoreManager.getStringData(APPLICATION_ID)
+
     companion object {
         const val SOCIAL_ACCESS_TOKEN = "social_access_token"
         const val ACCESS_TOKEN = "access_token"
+        const val VERSION_NAME = "version_name"
+        const val APPLICATION_ID = "application_id"
     }
 }

--- a/domain/src/main/java/app/threedollars/domain/repository/AppConfigRepository.kt
+++ b/domain/src/main/java/app/threedollars/domain/repository/AppConfigRepository.kt
@@ -1,0 +1,8 @@
+package app.threedollars.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface AppConfigRepository {
+    suspend fun saveVersionName(version: String): Flow<Unit>
+    suspend fun saveApplicationId(applicationId: String): Flow<Unit>
+}

--- a/domain/src/main/java/app/threedollars/domain/usecase/AppConfigUseCase.kt
+++ b/domain/src/main/java/app/threedollars/domain/usecase/AppConfigUseCase.kt
@@ -1,0 +1,8 @@
+package app.threedollars.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+
+interface AppConfigUseCase {
+    suspend fun saveVersionName(version: String): Flow<Unit>
+    suspend fun saveApplicationId(applicationId: String): Flow<Unit>
+}


### PR DESCRIPTION
클린 아키텍처 구조로 이뤄져 있다 보니 Data Module에서 App Module의 BuildConfig에 접근이 불가능하여 Splash 화면에서 BuildConfig 데이터를 로컬에 저장하는 방식으로 Config 데이터를 불러올 수 있게 작업했습니다.