### PR TITLE
[Feat] Compose에 맞는 위치정보권한 처리

### DIFF
--- a/app/src/main/java/app/threedollars/manager/util/SystemUtils.kt
+++ b/app/src/main/java/app/threedollars/manager/util/SystemUtils.kt
@@ -3,6 +3,7 @@ package app.threedollars.manager.util
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.pm.PackageManager
 import android.location.Address
 import android.location.Geocoder
 import android.util.Log
@@ -11,6 +12,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.core.app.ActivityCompat
 import app.threedollars.manager.R
 import com.naver.maps.geometry.LatLng
 import kotlinx.coroutines.Dispatchers
@@ -58,6 +60,10 @@ inline fun Modifier.noRippleClickable(crossinline onClick: ()->Unit): Modifier =
         interactionSource = remember { MutableInteractionSource() }) {
         onClick()
     }
+}
+
+fun Context.hasPermissions(permissions: List<String>): Boolean = permissions.all {
+    ActivityCompat.checkSelfPermission(this, it) == PackageManager.PERMISSION_GRANTED
 }
 
 suspend fun convertImageUrlToRequestBody(imageUrl: String): RequestBody? {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -55,6 +55,7 @@ object Dependencies {
             "androidx.navigation:navigation-compose:${Versions.COMPOSE_NAVIGATION}"
         const val COMPOSE_LIFECYCLE = "androidx.lifecycle:lifecycle-runtime-compose:${Versions.COMPOSE_LIFECYCLE}"
         const val COMPOSE_COIL = "io.coil-kt:coil-compose:${Versions.COMPOSE_COIL}"
+        const val COMPOSE_PERMISSIONS = "com.google.accompanist:accompanist-permissions:${Versions.COMPOSE_PERMISSIONS}"
     }
 
     object Paging {
@@ -121,6 +122,7 @@ object Dependencies {
         implementation(Compose.COMPOSE_VIEWMODEL)
         implementation(Compose.COMPOSE_NAVIGATION)
         implementation(Compose.COMPOSE_LIFECYCLE)
+        implementation(Compose.COMPOSE_PERMISSIONS)
         implementation(Paging.PAGING)
         implementation(Paging.PAGING_COMPOSE)
         kapt(Hilt.HILT_COMPILER)

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -22,6 +22,7 @@ object Versions {
     const val COMPOSE_NAVIGATION = "2.5.3"
     const val COMPOSE_LIFECYCLE = "2.6.0-alpha04"
     const val COMPOSE_COIL = "2.3.0"
+    const val COMPOSE_PERMISSIONS = "0.31.3-beta"
 
     const val PAGING = "3.1.1"
     const val PAGING_COMPOSE = "1.0.0-alpha18"


### PR DESCRIPTION
컴포즈용 권한처리가 따로 있는거에 더불어서
위치정보는 '정확한 위치', '대략적인 위치' 등 선택지까지 있어서 따로 빼서 관리하더라구요

[관련자료](https://github.com/google/accompanist/tree/main/sample/src/main/java/com/google/accompanist/sample/permissions)