### PR TITLE
[Feat] 매니페스트 변수 replace

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,7 +27,7 @@ android {
         applicationId = "app.threedollars.manager"
         minSdk = 23
         targetSdk = 33
-        versionCode = 1
+        versionCode = 2
         versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -46,7 +46,7 @@ android {
             )
             buildConfigField("String", "KAKAO_KEY", gradleLocalProperties(rootDir)["kakao_key_release"] as? String ?: "")
             buildConfigField("String", "BASE_URL", gradleLocalProperties(rootDir)["base_url_release"] as? String ?: "")
-            manifestPlaceholders["kakao_key"] = gradleLocalProperties(rootDir)["kakao_key_release"] as String
+            manifestPlaceholders["kakao_key"] = (gradleLocalProperties(rootDir)["kakao_key_release"] as String).replace("\"","")
             manifestPlaceholders["naver_map_client_id"] = gradleLocalProperties(rootDir)["naver_map_client_id"] as String
         }
         getByName("debug") {
@@ -64,7 +64,7 @@ android {
             }
             buildConfigField("String", "KAKAO_KEY", gradleLocalProperties(rootDir)["kakao_key_dev"] as? String ?: "")
             buildConfigField("String", "BASE_URL", gradleLocalProperties(rootDir)["base_url_dev"] as? String ?: "")
-            manifestPlaceholders["kakao_key"] = gradleLocalProperties(rootDir)["kakao_key_dev"] as String
+            manifestPlaceholders["kakao_key"] = (gradleLocalProperties(rootDir)["kakao_key_dev"] as String).replace("\"","")
             manifestPlaceholders["naver_map_client_id"] = gradleLocalProperties(rootDir)["naver_map_client_id"] as String
         }
     }


### PR DESCRIPTION
https://developers.kakao.com/docs/latest/ko/kakaologin/android#set-redirect-uri
기준으로 카카오웹 로그인의 경우는 스키마를 통해서 리다이렉션을 합니다.
저희 앱의 경우엔 BuildConfig에도 Kakaokey를 사용하고 매니페스트에서도 사용하다 보니
BuildConfig 특성상 String의 경우 "" 를 넣어서 문자열인걸로 인식시켜야 하기때문에 
매니페스트에서 "" 까지 인식해서 리다이렉트가 제대로 이루어지지 않아 로그인이 안되었네요
매니페스트변수의 경우엔 replace로 "를 빼는 작업 추가했습니다~ 

<img width="604" alt="스크린샷 2023-08-02 오후 2 47 28" src="https://github.com/3dollar-in-my-pocket/3dollar-in-my-pocket-manager-android/assets/23720035/1d20e1db-8daf-4d40-bf84-68133645c431">
