### PR TITLE
[Fix] - 프리셋 바텀 다이얼로그 간격 수정

### DIFF
--- a/feature/review/src/main/kotlin/app/threedollars/manager/feature/review/components/PresetBottomDialog.kt
+++ b/feature/review/src/main/kotlin/app/threedollars/manager/feature/review/components/PresetBottomDialog.kt
@@ -65,7 +65,7 @@ internal fun PresetBottomSheetDialog(
                     .padding(
                         start = 20.dp,
                         end = 20.dp,
-                        bottom = 20.dp
+                        bottom = 40.dp
                     )
                     .imePadding()
             ) {

--- a/feature/review/src/main/kotlin/app/threedollars/manager/feature/review/components/ReportBottomDialog.kt
+++ b/feature/review/src/main/kotlin/app/threedollars/manager/feature/review/components/ReportBottomDialog.kt
@@ -74,6 +74,7 @@ internal fun ReportBottomSheetDialog(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(20.dp)
+                    .padding(bottom = 40.dp)
                     .imePadding()
             ) {
                 Row(

--- a/feature/review/src/main/kotlin/app/threedollars/manager/feature/review/components/ReviewDetailScreen.kt
+++ b/feature/review/src/main/kotlin/app/threedollars/manager/feature/review/components/ReviewDetailScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -61,7 +60,10 @@ import app.threedollars.common.ui.Green
 import app.threedollars.common.ui.Red
 import app.threedollars.common.ui.White
 import app.threedollars.manager.feature.review.DialogType
-import app.threedollars.manager.feature.review.DialogType.*
+import app.threedollars.manager.feature.review.DialogType.PRESET_DIALOG
+import app.threedollars.manager.feature.review.DialogType.PRESET_EDIT_DIALOG
+import app.threedollars.manager.feature.review.DialogType.PRESET_WRITE_DIALOG
+import app.threedollars.manager.feature.review.DialogType.REPORT_DIALOG
 import app.threedollars.manager.feature.review.R
 import app.threedollars.manager.feature.review.ScreenType
 import app.threedollars.manager.feature.review.ScreenType.ALL_REVIEW
@@ -103,7 +105,6 @@ internal fun ReviewDetailScreen(
     Scaffold(
         modifier = Modifier
             .fillMaxSize(),
-        contentWindowInsets = WindowInsets(0.dp),
         topBar = {
             ReviewDetailTopBar(
                 onScreenTypeUpdate = onScreenTypeUpdate,


### PR DESCRIPTION
- 하단 시스템 네비게이션 바가 있는 경우 버튼과 UI가 겹치는 현상이 있어 간격을 수정 했습니다.